### PR TITLE
Bugfix/handle files to keep option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install -g digitalocean-go-wrapper
 To wrap a Go function and convert it into a Node.js package, use the following command:
 
 ```bash
-dogo-wrap --do_go_dir <path_to_go_project> --do_project_output <output_directory>
+dogo-wrap --do_go_dir <path_to_go_project> --do_project_output <output_directory> --files_to_keep '["file1.txt", "directory1/", "directory2/file_inside.txt"]'
 ```
 
 For more options, use the `--help` command:
@@ -70,6 +70,7 @@ man dogo-wrap
 
 - `--do_go_dir` or `-d`: Directory containing the Go files (default: `./`).
 - `--do_project_output`, `--out` or `-o`: Output directory for the wrapped project (default: `./do_wrapped_function/`).
+- `--files_to_keep`, `--ftk`: Array of files to keep in each of the function folders (default:` [".env"]`).
 
 ## Commands
 

--- a/man/dogo-wrap.1
+++ b/man/dogo-wrap.1
@@ -26,7 +26,7 @@ Output directory for the wrapped project (default: \fI./do_wrapped_function/\fR)
 \fB\-\-go_built_name\fR
 Name of the built Go binary (default: \fIcompiled_function\fR).
 .TP
-\fB\-\-files_to_keep\fR
+\fB\-\-files_to_keep\fR, \fB\-\-ftk\fR
 Array of files to keep in each of the function folders (default: \fI[".env"]\fR).
 .TP
 \fB\-\-keep_wrapper\fR

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -36,7 +36,7 @@ Options:
   -o, --out, 
   --do_project_output Output directory for the wrapped project (default: ${DEFAULT_DO_PROJECT_OUTPUT})
   --go_built_name     Name of the built Go binary (default: ${DEFAULT_GO_BUILT_NAME})
-  --files_to_keep     Array of files to keep in each of the function folders (default: ${DEFAULT_FILES_TO_KEEP})
+  --ftk, --files_to_keep  Array of files to keep in each of the function folders (default: ${DEFAULT_FILES_TO_KEEP})
   --keep_wrapper      Flag to keep the wrapper in Go. If false, it will delete this intermediate step (default: ${DEFAULT_KEEP_WRAPPER})
   --do_wrapper_output Output directory for the Go wrapper code (default: ${DEFAULT_DO_WRAPPER_OUTPUT})
   -v, --version       Show the version number
@@ -78,6 +78,7 @@ export async function runCLI(argv) {
       o: "do_project_output",
       out: "do_project_output",
       v: "version",
+      ftk: "files_to_keep"
     },
     default: {
       do_go_dir: DEFAULT_DO_GO_DIR,

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,21 +1,24 @@
 // Import required modules
-import convertDoGoProject, { DEFAULT_YAML_FILE, DEFAULT_GO_BUILT_NAME, DEFAULT_DO_WRAPPER_OUTPUT, DEFAULT_KEEP_WRAPPER, DEFAULT_FILES_TO_KEEP } from "./doProjectConverter.mjs";
+import convertDoGoProject, { 
+  DEFAULT_YAML_FILE, 
+  DEFAULT_GO_BUILT_NAME, 
+  DEFAULT_DO_WRAPPER_OUTPUT, 
+  DEFAULT_KEEP_WRAPPER, 
+  DEFAULT_FILES_TO_KEEP 
+} from "./doProjectConverter.mjs";
 import minimist from "minimist";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
-
 // Constants
 const DEFAULT_DO_GO_DIR = "./";
 const DEFAULT_DO_PROJECT_OUTPUT = "./do_wrapped_function/";
-
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const packageJsonPath = path.resolve(__dirname, '../package.json');
-
 
 // Function to print help message
 function printHelp() {
@@ -45,6 +48,26 @@ Examples:
   console.log(helpMessage);
 }
 
+// Function to cast arguments to the correct types
+function castArgs(args) {
+  if (typeof args.files_to_keep === 'string') {
+    try {
+      args.files_to_keep = JSON.parse(args.files_to_keep);
+      if (!Array.isArray(args.files_to_keep)) {
+        throw new Error('files_to_keep should be an array');
+      }
+    } catch (error) {
+      console.error('Invalid format for files_to_keep, it should be a JSON array');
+      process.exit(1);
+    }
+  }
+
+  // `keep_wrapper` is a flag, check its presence
+  args.keep_wrapper = args.keep_wrapper || false;
+
+  return args;
+}
+
 // Function to parse arguments and run the CLI
 export async function runCLI(argv) {
   const args = minimist(argv, {
@@ -65,6 +88,7 @@ export async function runCLI(argv) {
       files_to_keep: DEFAULT_FILES_TO_KEEP,
       keep_wrapper: DEFAULT_KEEP_WRAPPER,
     },
+    boolean: ['keep_wrapper'],  // Treat `keep_wrapper` as a boolean flag
   });
 
   if (args.help) {
@@ -78,13 +102,16 @@ export async function runCLI(argv) {
     return;
   }
 
+  // Cast arguments to correct types
+  const castedArgs = castArgs(args);
+
   await convertDoGoProject(
-    args.do_go_dir,
-    args.do_project_output,
-    args.yaml_file,
-    args.go_built_name,
-    args.files_to_keep,
-    args.keep_wrapper,
-    args.do_wrapper_output
+    castedArgs.do_go_dir,
+    castedArgs.do_project_output,
+    castedArgs.yaml_file,
+    castedArgs.go_built_name,
+    castedArgs.files_to_keep,
+    castedArgs.keep_wrapper,
+    castedArgs.do_wrapper_output
   );
 }

--- a/src/doProjectConverter.mjs
+++ b/src/doProjectConverter.mjs
@@ -122,7 +122,7 @@ function copyDoPackages(do_go_dir, tempDir, filesToKeep) {
   );
   if (filesToKeep && filesToKeep.length > 0) {
     filesToKeep.forEach((fileName) => {
-      try { 
+      try {
         copy(path.join(do_go_dir, fileName), path.join(tempDir, fileName));
       } catch (e) {}
     });
@@ -136,6 +136,7 @@ function copyDoPackages(do_go_dir, tempDir, filesToKeep) {
  * @param {string} functionPath - The function path.
  * @param {string} compiledGoFilePath - The compiled Go file path.
  * @param {string} go_built_name - The compiled binary file of the Go project.
+ * @param {Array<string>} filesToKeep - List of files to keep.
  * @returns {object} - The updated YAML data.
  */
 function convertIntoNodeJSPackage(
@@ -143,10 +144,11 @@ function convertIntoNodeJSPackage(
   tempDir,
   functionPath,
   compiledGoFilePath,
-  go_built_name
+  go_built_name,
+  filesToKeep
 ) {
   const fullPath = path.join(tempDir, functionPath);
-  removeFolderContent(fullPath);
+  removeFolderContent(fullPath, filesToKeep);
   copy(JS_WRAPPER_TEMPLATE_DIR, fullPath);
 
   const filePath = path.join(fullPath, NODEJS_PACKAGE_FILE);
@@ -185,7 +187,10 @@ async function convertDoGoProject(
   try {
     // Create temporary directory and copy necessary files
     checkDirExists(tempDir);
-    copyDoPackages(do_go_dir, tempDir, filesToKeep);
+
+    copyDoPackages(do_go_dir, tempDir, [
+      ...new Set([...filesToKeep, ...DEFAULT_FILES_TO_KEEP]),
+    ]); //always keep the default fields on the main folder
 
     let yamlData = getYamlData(do_go_dir);
 
@@ -210,7 +215,8 @@ async function convertDoGoProject(
         tempDir,
         func.goFunctionPath,
         compiledWrapper,
-        go_built_name
+        go_built_name,
+        filesToKeep
       );
     }
 

--- a/src/utils/fileUtils.mjs
+++ b/src/utils/fileUtils.mjs
@@ -41,27 +41,42 @@ export function writeJsonFile(filePath, data) {
 }
 
 /**
- * Removes the content of a folder, except for specified files.
+ * Removes the content of a folder, except for specified files and directories.
  * @param {string} folderPath - The path of the folder to clear.
  * @param {string[]} keepFiles - An array of file names to keep in the folder.
  */
 export function removeFolderContent(folderPath, keepFiles = []) {
   const files = fs.readdirSync(folderPath);
+
+  const normalizedKeepFiles = keepFiles.map((keepFile) => path.normalize(keepFile));
+
+
   for (const file of files) {
-    if (keepFiles.includes(file)) {
-      continue; // Skip files and directories that are in the keepFiles array
-    }
     const fullPath = path.join(folderPath, file);
+    const relativePath = path.relative(folderPath, fullPath);
+    const shouldKeep = normalizedKeepFiles.some((keepFile) => {
+      return fullPath.includes(keepFile) || relativePath === keepFile;
+    });
+
+    if (shouldKeep) {
+      continue;
+    }
+
     if (fs.lstatSync(fullPath).isDirectory()) {
       removeFolderContent(fullPath, keepFiles);
       try {
         fs.rmdirSync(fullPath);
-      } catch (e) {}
+      } catch (e) {
+      }
     } else {
-      fs.unlinkSync(fullPath);
+      try {
+        fs.unlinkSync(fullPath);
+      } catch (e) {
+      }
     }
   }
 }
+
 
 /**
  * Copies the contents of a source to a destination.

--- a/test/fileUtils.test.mjs
+++ b/test/fileUtils.test.mjs
@@ -110,7 +110,7 @@ describe("File Utils test", function () {
     });
 
     it('should remove all files and directories except the specified ones', () => {
-      const keepFiles = ['file1.txt', 'subdir'];
+      const keepFiles = ['file1.txt', 'subdir/'];
 
       removeFolderContent(testDir, keepFiles);
 

--- a/test/fileUtils.test.mjs
+++ b/test/fileUtils.test.mjs
@@ -90,44 +90,47 @@ describe("File Utils test", function () {
 
   describe('removeFolderContent', () => {
     let testDir;
-  
+
     beforeEach(() => {
       // Create a temporary directory for testing
       testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'testDir-'));
-  
+
       // Create some files and directories inside the test directory
       fs.writeFileSync(path.join(testDir, 'file1.txt'), 'content1');
       fs.writeFileSync(path.join(testDir, 'file2.txt'), 'content2');
       fs.mkdirSync(path.join(testDir, 'subdir'));
       fs.writeFileSync(path.join(testDir, 'subdir', 'file3.txt'), 'content3');
+      fs.mkdirSync(path.join(testDir, 'subdir', 'nestedsubdir'));
+      fs.writeFileSync(path.join(testDir, 'subdir', 'nestedsubdir', 'file4.txt'), 'content4');
     });
-  
+
     afterEach(() => {
       // Remove the test directory after each test
       fs.rmSync(testDir, { recursive: true, force: true });
     });
-  
+
     it('should remove all files and directories except the specified ones', () => {
       const keepFiles = ['file1.txt', 'subdir'];
-  
+
       removeFolderContent(testDir, keepFiles);
-  
+
       // Check that file1.txt and subdir still exist
       expect(fs.existsSync(path.join(testDir, 'file1.txt'))).to.be.true;
       expect(fs.existsSync(path.join(testDir, 'subdir'))).to.be.true;
-  
+
       // Check that file2.txt and subdir/file3.txt have been removed
       expect(fs.existsSync(path.join(testDir, 'file2.txt'))).to.be.false;
+      expect(fs.existsSync(path.join(testDir, 'subdir', 'file3.txt'))).to.be.true;
     });
-  
+
     it('should remove all files and directories if keepFiles is empty', () => {
       removeFolderContent(testDir);
-  
+
       // Check that the directory is empty
       const remainingFiles = fs.readdirSync(testDir);
       expect(remainingFiles).to.be.empty;
     });
-  
+
     it('should not fail if the folder is already empty', () => {
       // Clear the test directory manually
       fs.readdirSync(testDir).forEach((file) => {
@@ -138,15 +141,42 @@ describe("File Utils test", function () {
           fs.unlinkSync(fullPath);
         }
       });
-  
+
       removeFolderContent(testDir);
-  
+
       // Check that the directory is still empty
       const remainingFiles = fs.readdirSync(testDir);
       expect(remainingFiles).to.be.empty;
     });
-  });
 
+    it('should correctly skip nested files and directories specified in keepFiles', () => {
+      const keepFiles = ['subdir/nestedsubdir/file4.txt'];
+
+      removeFolderContent(testDir, keepFiles);
+
+      // Check that nested file still exists
+      expect(fs.existsSync(path.join(testDir, 'subdir', 'nestedsubdir', 'file4.txt'))).to.be.true;
+
+      // Check that other files have been removed
+      expect(fs.existsSync(path.join(testDir, 'file1.txt'))).to.be.false;
+      expect(fs.existsSync(path.join(testDir, 'file2.txt'))).to.be.false;
+      expect(fs.existsSync(path.join(testDir, 'subdir', 'file3.txt'))).to.be.false;
+    });
+
+    it('should correctly handle relative paths in keepFiles', () => {
+      const keepFiles = ['subdir/file3.txt'];
+
+      removeFolderContent(testDir, keepFiles);
+
+      // Check that specified file still exists
+      expect(fs.existsSync(path.join(testDir, 'subdir', 'file3.txt'))).to.be.true;
+
+      // Check that other files have been removed
+      expect(fs.existsSync(path.join(testDir, 'file1.txt'))).to.be.false;
+      expect(fs.existsSync(path.join(testDir, 'file2.txt'))).to.be.false;
+      expect(fs.existsSync(path.join(testDir, 'subdir', 'nestedsubdir', 'file4.txt'))).to.be.false;
+    });
+  });
 
   describe("copy", function () {
     it("should copy contents from source to destination", function () {


### PR DESCRIPTION
### Description

This pull request addresses several improvements and fixes:

1. **Bug Fix**: The `--files_to_keep` option in the `dogo-wrap` command was causing the main code to break unexpectedly. The changes ensure that specified files are properly excluded from deletion.
2. **New Feature**: Added an alias `ftk` for the `files_to_keep` option to make it easier to use.
3. **Documentation Update**: Updated the README.md and manual to reflect the new alias `ftk` for the `files_to_keep` option.
4. **CLI Argument Casting**: Improved type checking and casting for CLI arguments to ensure they are correctly parsed and handled.

- **Related Issue**: Closes #13  
- **Type of Change**:
  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)
  - Documentation update

### Checklist

Please ensure the following guidelines are met:

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information

This fix ensures that the `dogo-wrap` command can correctly handle the `--files_to_keep` option and its alias `ftk`, improving its functionality and stability. The documentation has been updated to reflect these changes. Additionally, type checking and casting for CLI arguments have been improved to ensure they are correctly parsed and handled. No new dependencies are introduced.
